### PR TITLE
Add frontend documentation and diagram

### DIFF
--- a/docs/frontend-pages.svg
+++ b/docs/frontend-pages.svg
@@ -1,0 +1,18 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="400" height="200" fill="#f8fafc"/>
+  <rect x="20" y="50" width="100" height="40" fill="#cbd5e1" stroke="#334155"/>
+  <text x="70" y="75" font-family="Arial" font-size="14" text-anchor="middle" dominant-baseline="middle">/welcome</text>
+  <rect x="150" y="50" width="100" height="40" fill="#cbd5e1" stroke="#334155"/>
+  <text x="200" y="75" font-family="Arial" font-size="14" text-anchor="middle" dominant-baseline="middle">/auth</text>
+  <rect x="280" y="50" width="100" height="40" fill="#cbd5e1" stroke="#334155"/>
+  <text x="330" y="75" font-family="Arial" font-size="14" text-anchor="middle" dominant-baseline="middle">/dashboard</text>
+  <rect x="150" y="130" width="100" height="40" fill="#cbd5e1" stroke="#334155"/>
+  <text x="200" y="155" font-family="Arial" font-size="14" text-anchor="middle" dominant-baseline="middle">/loading</text>
+  <line x1="120" y1="70" x2="150" y2="70" stroke="#334155" marker-end="url(#arrow)" />
+  <line x1="250" y1="70" x2="280" y2="70" stroke="#334155" marker-end="url(#arrow)" />
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="6" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#334155" />
+    </marker>
+  </defs>
+</svg>

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,21 @@
+# Zentix Frontend
+
+This directory contains the Next.js interface for the Zentix platform.
+
+## Setup
+
+```bash
+npm install
+npm run dev
+```
+
+The development server will be available at `http://localhost:3000` by default.
+
+## Available Pages
+
+- **`/welcome`** – Introductory page with a call to action.
+- **`/auth`** – Login form for authenticating users.
+- **`/dashboard`** – Main AI dashboard (also served from `/`).
+- **`/loading`** – Full-screen loading indicator.
+
+![Frontend pages diagram](../docs/frontend-pages.svg)


### PR DESCRIPTION
## Summary
- document frontend setup and pages
- include a simple page diagram in `docs`

## Testing
- `npm test` *(fails: Invalid package.json)*
- `pytest` *(fails: unrecognized arguments --cov=app)*

------
https://chatgpt.com/codex/tasks/task_e_684b202956cc8330b62948777886cf77