### PR TITLE
Add framer-motion effect demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ zentix-clean/
 │       └── test_integration.py
 ├── frontend/
 │   ├── components/
+│   │   └── ui/
+│   │       ├── effects/
+│   │       └── animations/
 │   ├── pages/
 │   └── tests/
 ├── docs/
@@ -96,6 +99,8 @@ zentix-clean/
     ├── setup.sh
     └── deploy.sh
 ```
+
+يضم مجلد **frontend/components/ui** مجلدين فرعيين `effects/` و `animations/` يضمان أمثلة مبسطة لاستخدام مكتبة **framer-motion** مثل `FadeIn.tsx` و `SlideIn.tsx`.
 
 ## المساهمة
 

--- a/frontend/components/ui/animations/SlideIn.tsx
+++ b/frontend/components/ui/animations/SlideIn.tsx
@@ -1,0 +1,26 @@
+import { motion } from 'framer-motion';
+import { HTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+interface SlideInProps extends HTMLAttributes<HTMLDivElement> {
+  offset?: number;
+  duration?: number;
+}
+
+export const SlideIn = ({
+  children,
+  offset = 20,
+  duration = 0.5,
+  className,
+  ...props
+}: SlideInProps) => (
+  <motion.div
+    initial={{ opacity: 0, y: offset }}
+    animate={{ opacity: 1, y: 0 }}
+    transition={{ duration }}
+    className={twMerge(className)}
+    {...props}
+  >
+    {children}
+  </motion.div>
+);

--- a/frontend/components/ui/effects/FadeIn.tsx
+++ b/frontend/components/ui/effects/FadeIn.tsx
@@ -1,0 +1,19 @@
+import { motion } from 'framer-motion';
+import { HTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+interface FadeInProps extends HTMLAttributes<HTMLDivElement> {
+  duration?: number;
+}
+
+export const FadeIn = ({ children, duration = 0.5, className, ...props }: FadeInProps) => (
+  <motion.div
+    initial={{ opacity: 0 }}
+    animate={{ opacity: 1 }}
+    transition={{ duration }}
+    className={twMerge(className)}
+    {...props}
+  >
+    {children}
+  </motion.div>
+);


### PR DESCRIPTION
## Summary
- add `FadeIn` and `SlideIn` components demonstrating framer-motion
- document new `effects/` and `animations/` folders in README

## Testing
- `pytest` *(fails: unrecognized arguments)*
- `npm run lint` in `frontend` *(fails: invalid package.json)*


------
https://chatgpt.com/codex/tasks/task_e_684b21396014833093165a850594b937