### PR TITLE
Add Kubernetes deployment YAML

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -196,3 +196,13 @@ docker-compose exec [service_name] sh
 - Security headers
 - Input validation
 - Rate limiting 
+## Kubernetes Deployment
+
+A basic Kubernetes configuration is provided in `k8s/deployment.yml`. It creates deployments and services for the backend and frontend. Apply it with:
+
+```bash
+kubectl apply -f k8s/deployment.yml
+```
+
+This configuration runs a single replica of each component in the `zentix` namespace. Update image tags and resources as needed.
+

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -1,1 +1,67 @@
- 
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zentix-backend
+  namespace: zentix
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zentix-backend
+  template:
+    metadata:
+      labels:
+        app: zentix-backend
+    spec:
+      containers:
+        - name: backend
+          image: zentix/backend:latest
+          ports:
+            - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zentix-backend
+  namespace: zentix
+spec:
+  selector:
+    app: zentix-backend
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zentix-frontend
+  namespace: zentix
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zentix-frontend
+  template:
+    metadata:
+      labels:
+        app: zentix-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: zentix/frontend:latest
+          ports:
+            - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zentix-frontend
+  namespace: zentix
+spec:
+  selector:
+    app: zentix-frontend
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000


### PR DESCRIPTION
## Summary
- add Kubernetes deployment YAML for backend and frontend
- document new k8s deployment configuration

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: missing plugins)*

------
https://chatgpt.com/codex/tasks/task_e_684b9ee9acd083308b72e15ffe85dc38