### PR TITLE
Streamline root Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,22 @@
-# Use official Python base image
 FROM python:3.11-slim
 
-# Set environment variables
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
 
-# Set work directory
 WORKDIR /app
 
-# Install system dependencies
+# Install build tools required for some Python packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
+        build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
-COPY requirements.txt .
+# Install backend requirements
+COPY backend/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy project
-COPY . .
+# Copy backend source
+COPY backend ./backend
 
-# Command to run the application
-CMD ["uvicorn", "backend.app:app", "--host", "0.0.0.0", "--port", "8000"]
+WORKDIR /app/backend
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- clean up the root Dockerfile to only build the backend
- install backend requirements and copy backend source
- run the backend with uvicorn

## Testing
- `pytest -q` *(fails: unrecognized arguments because required plugins can't be installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ba21c6ab08330926596b2f0b001c2