### PR TITLE
Clean deployment docs

### DIFF
--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -44,34 +44,18 @@ Zentix هو تطبيق ويب متقدم مبني باستخدام Next.js و Ty
 
 ### اختبارات الوحدة
 ```bash
- codex/decide-on-root-package.json-usage
-cd frontend
-npm run test
-=======
 cd frontend && npm run test
- main
 ```
 
 ### اختبارات التكامل
 ```bash
- codex/decide-on-root-package.json-usage
-cd frontend
-npm run test:integration
-=======
 cd frontend && npm run test:integration
- main
 ```
 
 ### اختبارات الأداء
 ```bash
- codex/decide-on-root-package.json-usage
-cd frontend
-npm run test:performance
-=======
 cd frontend && npm run test:performance
- main
 ```
-
 ## CI/CD
 
 ### مراحل CI/CD
@@ -144,4 +128,4 @@ cd frontend && npm run test:performance
 - Jest
 
 ## الترخيص
-MIT License 
+MIT License

--- a/docs/deployment.ar.md
+++ b/docs/deployment.ar.md
@@ -141,15 +141,7 @@ POSTGRES_DB=zentix
    ```
 
   ### معالجة الخلفية
-  يتم استضافة الخلفية بشكل منفصل (Docker أو خدمة سحابية) مع إتاحة عنوانها
- codex/verify-environment-variables-for-production
-  العام، ثم ضبط `NEXT_PUBLIC_API_URL` في لوحة Vercel حتى تتمكن الواجهة
-  الأمامية من الوصول إلى واجهة البرمجة. سيفشل بناء الإنتاج إذا لم يكن هذا
-  المتغير محدداً.
-
-  العام، ثم ضبط `NEXT_PUBLIC_API_URL` في لوحة Vercel أو في `vercel.json` حتى
-  تتمكن الواجهة الأمامية من الوصول إلى واجهة البرمجة.
- main
+يتم استضافة الخلفية بشكل منفصل (Docker أو خدمة سحابية) مع إتاحة عنوانها العام، ثم ضبط `NEXT_PUBLIC_API_URL` في لوحة Vercel أو في `vercel.json` حتى تتمكن الواجهة الأمامية من الوصول إلى واجهة البرمجة. سيفشل بناء الإنتاج إذا لم يكن هذا المتغير محدداً.
 
   ### ملف vercel.json
   يحدّد ملف `vercel.json` إعدادات المشروع ومجلد
@@ -160,19 +152,7 @@ POSTGRES_DB=zentix
   - `NEXT_PUBLIC_API_URL` – رابط خدمة الباكند
   - `NEXT_PUBLIC_JWT_STORAGE_KEY` – مفتاح تخزين رمز المصادقة
 
- codex/verify-environment-variables-for-production
-  يتم إعادة توجيه الطلبات `/api/*` إلى الخلفية لكي يبقى العنوان موحداً.
-
- codex/remove-trailing-fragments-from-files
-  يتم إعادة تواجه اطلابات `/api/*` إلى الخلفية لكي يبقى العنوان موحداً.
- 1nm7v7-codex/remove-trailing-fragments-from-files
-=======
-
-  تتم إعادة كتابة الطلبات التي تبدأ بـ`/api/` إلى عنوان الخلفية. حدّث
-  الرابط الافتراضي `http://localhost:5000/api` بما يناسب بيئة الإنتاج.
- main
- main
- main
+تتم إعادة كتابة الطلبات التي تبدأ بـ`/api/` إلى عنوان الخلفية كي يبقى العنوان موحداً. حدّث الرابط الافتراضي `http://localhost:5000/api` بما يناسب بيئة الإنتاج.
 
 ## الصيانة
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -142,15 +142,7 @@ address of the backend API. Production builds verify this variable is set.
    ```
 
 ### Backend Handling
-Host the backend separately (Docker, VPS, or any cloud provider) and expose
- codex/verify-environment-variables-for-production
-its public URL. Set `NEXT_PUBLIC_API_URL` in the Vercel dashboard so the
-frontend can reach the API. The production build will fail if this variable is
-missing.
-=======
-its public URL. Configure `NEXT_PUBLIC_API_URL` in the Vercel dashboard or in
-`vercel.json` so the frontend can reach the API.
- main
+Host the backend separately (Docker, VPS, or any cloud provider) and expose its public URL. Configure `NEXT_PUBLIC_API_URL` in the Vercel dashboard or in `vercel.json` so the frontend can reach the API. The production build will fail if this variable is missing.
 
 ### Configuration File
 This repository provides a `vercel.json` file that defines the project
@@ -161,19 +153,7 @@ application:
 - `NEXT_PUBLIC_API_URL` – URL of the backend API
 - `NEXT_PUBLIC_JWT_STORAGE_KEY` – key used to store the authentication token
 
-Requests to `/api/*` are rewritten to the backend so the frontend can call the
- codex/remove-trailing-fragments-from-files
-API without hard‑coding the server address.
- 1nm7v7-codex/remove-trailing-fragments-from-files
-=======
- codex/verify-environment-variables-for-production
-=======
-=======
-API without hard‑coding the server address. Update the destination URL from
-`http://localhost:5000/api` to your deployed backend address.
- main
- main
- main
+Requests to `/api/*` are rewritten to the backend so the frontend can call the API without hard-coding the server address. Update the destination URL from `http://localhost:5000/api` to your deployed backend address.
 
 ## Maintenance
 
@@ -261,23 +241,7 @@ docker-compose exec [service_name] sh
 - Regular updates
 - Security headers
 - Input validation
- 1nm7v7-codex/remove-trailing-fragments-from-files
 - Rate limiting 
-- Rate limiting
-
-=======
- codex/verify-environment-variables-for-production
-- Rate limiting
-=======
- codex/remove-trailing-fragments-from-files
-- Rate limiting 
-- Rate limiting
-
-=======
-- Rate limiting
- main
- main
- main
 ## Kubernetes Deployment
 
 A Kubernetes configuration is provided in `k8s/deployment.yml`. Apply it with:
@@ -286,15 +250,4 @@ A Kubernetes configuration is provided in `k8s/deployment.yml`. Apply it with:
 kubectl apply -f k8s/deployment.yml
 ```
 
-This configuration runs a single replica of each component in the `zentix` namespace. Update image tags and resources as needed.
- codex/remove-trailing-fragments-from-files
-
-The file defines deployments and services for the frontend and backend in the `zentix` namespace. Update image tags and resources as needed.
- 1nm7v7-codex/remove-trailing-fragments-from-files
-=======
- codex/verify-environment-variables-for-production
-=======
-=======
- main
- main
- main
+This configuration runs a single replica of each component in the `zentix` namespace and defines deployments and services for the frontend and backend. Update image tags and resources as needed.


### PR DESCRIPTION
## Summary
- clean merge conflict markers from deployment guides
- clarify API URL instructions and Kubernetes notes
- tidy technical documentation commands

## Testing
- `pre-commit run --files docs/deployment.md docs/deployment.ar.md docs/TECHNICAL.md` *(fails: command not found)*
- `pytest -k nothing` *(fails: pyproject parse error)*

------
https://chatgpt.com/codex/tasks/task_e_684bb7559ed48330b436f2d229f628b0