### PR TITLE
Fix AI agent fetch path

### DIFF
--- a/frontend/components/ai/AIAgent.tsx
+++ b/frontend/components/ai/AIAgent.tsx
@@ -61,7 +61,7 @@ export const AIAgent: React.FC<AIAgentProps> = ({
     setInput('');
 
     try {
-      const response = await fetch('/api/ai-agent', {
+      const response = await fetch('/api/chat/message', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- update chat fetch URL in AIAgent
- verify other API utilities use `/api/chat/message`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb7c981f883309a1a4ab96c8c8704